### PR TITLE
Complete Code Along

### DIFF
--- a/lib/custom_errors.rb
+++ b/lib/custom_errors.rb
@@ -6,16 +6,25 @@ class Person
   end
 
   def get_married(person)
-    self.partner = person
-    person.partner = self
+    if person.is_a?(Person)
+      self.partner = person
+      person.partner = self
+    else
+      begin
+        raise PartnerError
+      rescue PartnerError => error
+        puts error.message
+      end
+    end
   end
 
+  class PartnerError < StandardError
+    def message
+      "you must give the get_married method an argument of an instance of the person class!"
+    end
+  end
 end
 
 beyonce = Person.new("Beyonce")
 beyonce.get_married("Jay-Z")
 puts beyonce.name
-
-
-
-


### PR DESCRIPTION
This pull request introduces error handling to the `get_married` method in the `Person` class to ensure that only instances of the `Person` class can be passed as an argument. It also defines a custom error class, `PartnerError`, to provide a clear and specific error message when invalid arguments are provided.

### Error handling improvements:
* [`lib/custom_errors.rb`](diffhunk://#diff-06bd9ecc27509b84dca89dc1a29b9331897510f9917738b7314cbe63ec372663R9-L21): Added a type check in the `get_married` method to verify that the `person` argument is an instance of the `Person` class. If not, a `PartnerError` is raised and handled with a custom error message.
* [`lib/custom_errors.rb`](diffhunk://#diff-06bd9ecc27509b84dca89dc1a29b9331897510f9917738b7314cbe63ec372663R9-L21): Introduced a new custom error class, `PartnerError`, which inherits from `StandardError` and provides a descriptive error message.